### PR TITLE
docs(readme): fix object init

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Import the SDK and instantiate a new client with your authentication secrets:
 ```python
 from jinaai import JinaAI
 
-jinaai = new JinaAI(
+jinaai = JinaAI(
     secrets = {
         'promptperfect-secret': 'XXXXXX',
         'scenex-secret': 'XXXXXX',


### PR DESCRIPTION
Code snippet had weird `new` thing in it. This PR fixes it

## Before

```python
from jinaai import JinaAI

jinaai = new JinaAI(
    secrets = {
        'promptperfect-secret': 'XXXXXX',
        'scenex-secret': 'XXXXXX',
        'rationale-secret': 'XXXXXX',
        'jinachat-secret': 'XXXXXX',
    }
)
```