### PR TITLE
Fix mergedHeaders assignment in JinaChatClient.py

### DIFF
--- a/jinaai/clients/JinaChatClient.py
+++ b/jinaai/clients/JinaChatClient.py
@@ -8,7 +8,7 @@ class JinaChatClient(HTTPClient):
             'Content-Type': 'application/json',
         }
         mergedHeaders = defaultHeaders.update(headers)
-        super().__init__(baseUrl=baseUrl, headers=defaultHeaders, options=options)
+        super().__init__(baseUrl=baseUrl, headers=mergedHeaders, options=options)
 
     def from_array(self, input, options=None):
         return {


### PR DESCRIPTION
The pull request introduces a correction to the assignment of `mergedHeaders` in the `JinaChatClient.py` file. It involves a minor code adjustment, modifying one line to fix how headers are merged. This change ensures headers are properly combined as intended.